### PR TITLE
Initialise variables used in drawing code

### DIFF
--- a/src/SEQ16.cpp
+++ b/src/SEQ16.cpp
@@ -83,7 +83,7 @@ struct SEQ16 : Module {
 	}
 	void step() override;
 
-	int numSteps;
+	int numSteps = 0;
 
 	json_t *toJson() override {
 		json_t *rootJ = json_object();


### PR DESCRIPTION
Module variables used in draw() need to be initialised to sensible values, otherwise if a module is added when the engine is paused, it will crash (or show garbage).