### PR TITLE
Fix memory issues on freeverb side

### DIFF
--- a/freeverb/allpass.hpp
+++ b/freeverb/allpass.hpp
@@ -21,12 +21,12 @@ public:
 
 	~allpass()
 	{
-		if (buffer) delete buffer;
+		if (buffer) delete[] buffer;
 	};
 
         void    makebuffer(float *buf, int size)
         {
-		if (buffer) delete buffer;
+		if (buffer) delete[] buffer;
                 buffer = new float[size];
                 bufsize = size;
 		bufidx = 0;
@@ -34,7 +34,7 @@ public:
 
         void    deletebuffer()
         {
-                if(buffer) delete buffer;
+                if(buffer) delete[] buffer;
                 bufsize = 0;
         };
 

--- a/freeverb/comb.hpp
+++ b/freeverb/comb.hpp
@@ -23,12 +23,12 @@ public:
 
 	~comb()
 	{
-		if (buffer) delete buffer;
+		if (buffer) delete[] buffer;
 	};
 
 	void    makebuffer(float *buf, int size) 
 	{
-		if (buffer) {delete buffer;}
+		if (buffer) {delete[] buffer;}
 		buffer = new float[size];
 		bufsize = size;
 		bufidx = 0;
@@ -36,7 +36,7 @@ public:
 
 	void	deletebuffer()
 	{
-		if(buffer) delete buffer;
+		if(buffer) delete[] buffer;
 		bufsize = 0;
 	};
 

--- a/freeverb/revmodel.cpp
+++ b/freeverb/revmodel.cpp
@@ -73,13 +73,16 @@ void revmodel::init(const float sampleRate)
 
 	feedback_allpass = 0.5;
 
-	setwet(initialwet);
-	setroomsize(initialroom);
-	setdry(initialdry);
-	setdamp(initialdamp);
-	setwidth(initialwidth);
-	setmode(initialmode);
+	// safely initialize all values first
+	wet = initialwet * scalewet;
+	roomsize = (initialroom * scaleroom) + offsetroom;
+	dry = initialdry * scaledry;
+	damp = initialdamp * scaledamp * sqrt(conversion);
+	width = initialwidth;
+	mode = initialmode;
 
+	// now we can call update after all values are initialized
+	update();
 
 	// Buffer will be full of rubbish - so we MUST mute them
 	mute();


### PR DESCRIPTION
As detected by valgrind.
Related log:

```
==860999== Conditional jump or move depends on uninitialised value(s)
==860999==    at 0xC77AA2: ASrevmodel::update() (revmodel.cpp:141)
==860999==    by 0xC77C7E: ASrevmodel::setwet(float) (revmodel.cpp:190)
==860999==    by 0xC7774A: ASrevmodel::init(float) (revmodel.cpp:76)
==860999==    by 0xC1C892: ReverbFx::ReverbFx() (Reverb.cpp:78)
==860999==    by 0xC1E493: rack::CardinalPluginModel<ReverbFx, ReverbFxWidget>::createModule() (helpers.hpp:52)
==860999==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==860999==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==860999==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==860999==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==860999==  Uninitialised value was created by a heap allocation
==860999==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==860999==    by 0xC1E488: rack::CardinalPluginModel<ReverbFx, ReverbFxWidget>::createModule() (helpers.hpp:52)
==860999==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==860999==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==860999==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==860999==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==860999== 

==866681== Mismatched free() / delete / delete []
==866681==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==866681==    by 0xC77E1C: AScomb::makebuffer(float*, int) (comb.hpp:31)
==866681==    by 0xC773ED: ASrevmodel::init(float) (revmodel.cpp:48)
==866681==    by 0xC1CBA1: ReverbFx::onSampleRateChange() (Reverb.cpp:91)
==866681==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==866681==    by 0x24A46AD: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==866681==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==866681==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==866681==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==866681==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==866681==  Address 0x9c10030 is 0 bytes inside a block of size 4,464 alloc'd
==866681==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==866681==    by 0xC77E43: AScomb::makebuffer(float*, int) (comb.hpp:32)
==866681==    by 0xC773ED: ASrevmodel::init(float) (revmodel.cpp:48)
==866681==    by 0xC1C892: ReverbFx::ReverbFx() (Reverb.cpp:78)
==866681==    by 0xC1E493: rack::CardinalPluginModel<ReverbFx, ReverbFxWidget>::createModule() (helpers.hpp:52)
==866681==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==866681==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==866681==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==866681==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==866681== 

==867243== Mismatched free() / delete / delete []
==867243==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==867243==    by 0xC77FF6: ASallpass::makebuffer(float*, int) (allpass.hpp:29)
==867243==    by 0xC7762F: ASrevmodel::init(float) (revmodel.cpp:65)
==867243==    by 0xC1CBA9: ReverbFx::onSampleRateChange() (Reverb.cpp:91)
==867243==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==867243==    by 0x24A46BD: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==867243==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==867243==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==867243==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==867243==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==867243==  Address 0x9c1b040 is 0 bytes inside a block of size 2,224 alloc'd
==867243==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==867243==    by 0xC7801D: ASallpass::makebuffer(float*, int) (allpass.hpp:30)
==867243==    by 0xC7762F: ASrevmodel::init(float) (revmodel.cpp:65)
==867243==    by 0xC1C89A: ReverbFx::ReverbFx() (Reverb.cpp:78)
==867243==    by 0xC1E49B: rack::CardinalPluginModel<ReverbFx, ReverbFxWidget>::createModule() (helpers.hpp:52)
==867243==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==867243==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==867243==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==867243==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==867243== 
```