### PR TITLE
Fix memory leak

### DIFF
--- a/src/Phaser.cpp
+++ b/src/Phaser.cpp
@@ -161,8 +161,10 @@ struct PhaserFx : Module{
 		configInput(BYPASS_CV_INPUT, "Bypass CV");
 		//Outputs
 		configOutput(OUT, "Audio");
+	}
 
-
+	~PhaserFx() override {
+		delete pha;
 	}
 
 	void process(const ProcessArgs &args) override;


### PR DESCRIPTION
Detected by valgrind, `pha` is allocated on init but never deleted.

```
==890428== 76 bytes in 1 blocks are definitely lost in loss record 2,300 of 3,615
==890428==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0xC0F52A: PhaserFx::PhaserFx() (Phaser.cpp:145)
==890428==    by 0xC10E2F: rack::CardinalPluginModel<PhaserFx, PhaserFxWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428==
```